### PR TITLE
Feature: Assign allocations to environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,34 @@ This can be caused from any of the following: Wrong location, not enough disk sp
 The customer gets an email from the panel to setup their account (incl. password) if they didn't have an account before. Otherwise they should be able to use their existing credentials.
 
 ## My game requires multiple ports allocated.
-Configure the "Additional Ports" option in the module settings.
-It expects a comma-separated list of ports as a numeric offset from the first available allocation.
-E.g: If you enter `1,2,4` and the first available port happens to be 25565, you'll get as additional allocations: (If they're available) 
+Configure the "**Additional Ports**" option in the module settings.
+It expects a valid JSON string consisting of the parameter name or NONE, and a number representing a port as a numeric offset from the first available allocation.
+E.g: If you enter `{"NONE":1, "NONE":2, "NONE":4}` and the first available port happens to be 25565, you'll get as additional allocations: 
 * 25566 (First Port + 1)
 * 25567 (First Port +2)
 * 25569 (First Port +4)
 
-Note: Currently if this option is set, will override anything specified under "port_range" - Use one or the other.
+(If they're available)
 
-You'll also want to configure "Additional Port Failure Mode".
+Note: I this option is set, it will override anything specified under "port_range" - Use one or the other, not both.
+
+You'll also want to configure "**Additional Port Failure Mode**".
 This determines what the module should do if there are no allocations available on any of the defined nodes.
 * "Continue" - Continues creating the server but only with one allocation, whatever is available at the time. You'll need to manually go in after the server gets created to assign additional ports as required.
 * "Stop" - Stops the server creation and raises an error.
+
+## How to assign additional allocations to server parameters like RCON_PORT
+See the table below for "Additional Ports" example values.
+*These examples assume your WISP node has allocations available from 1000-2000.*
+
+| Game | Required Ports  |Additional Ports Example  | Ports Assigned  |
+| ------------ | ------------ | ------------ |
+| Rust | Game port and RCON port | `{"RCON_PORT":1}`  | Game Port: 1000, RCON_PORT: 1001|
+| Arma 3 | Game port, Game port +1 for Steam Query, Game port + 2 for Steam Port, and Game port +4 for BattleEye |  `{"NONE":1, "NONE":2, "NONE":4}` | Game Port: 1000, Additional Ports: 1001, 1002, 1004 |
+| Unturned | Game port, Game port +1 and Game port +2 | `{"NONE":1, "NONE":2}` | Game Port: 1000, Additional Ports: 1001, 1002 |
+| Project Zomboid | Game Port, Steam port and an additional port for every player. Let's say we want 10 additional ports for 10 players. | `{"STEAM_PORT": 1, "NONE": 2, "NONE": 3, "NONE": 4, "NONE": 5, "NONE": 6, "NONE": 7, "NONE": 8, "NONE": 9, "NONE": 10, "NONE":11}` | Game Port: 1000, Steam Port: 1001, Additional Ports: 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010, 1011|
+**What does "NONE" mean?**
+"NONE" means you want to assign the additional port to the server, but it doesn't need to be assigned to a server parameter. If instead you want to add a +1 allocation and assign it to the parameter "RCON_PORT then you'd use `{"RCON_PORT":1}` for example.
 
 ## How to enable module debug log
 1. In WHMCS 7 or below navigate to Utilities > Logs > Module Log. For WHMCS 8.x navigate to System Logs > Module Log in the left sidebar.

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -423,6 +423,20 @@ function wisp_CreateAccount(array $params) {
                         
                         $serverData['allocation']['default'] = intval($final_allocations['main_allocation_id']);
                         $serverData['allocation']['additional'] = $final_allocations['additional_allocation_ids'];
+
+                        // Update the start command - game port
+                        logActivity("Starting to update command: ".$startup);
+                        $startup = str_replace("{{game_port}}", $final_allocations['main_allocation_port'], $startup);
+                        logActivity("Replacing game_port with ". $final_allocations['main_allocation_port']);
+                        $idx = 1;
+                        // Update the start command - additional allocations
+                        foreach($final_allocations['additional_allocation_ports'] as $key => $port) {
+                            logActivity("Replacing additional_port_".$idx." with ". $port);
+                            $startup = str_replace("{{additional_port_".$idx."}}", $port, $startup);
+                            $idx++;
+                        }
+                        logActivity("The final startup command is: " . $startup);
+                        $serverData['startup'] = $startup;
                         // We successfully found an available allocation, break and check no more nodes.
                         break;
                     }
@@ -788,7 +802,7 @@ function findFreePorts(array $available_allocations, array $port_offsets) {
         logActivity("Checking IP: ".$ip_addr);
         foreach($ports as $port => $portDetails) {
             $main_allocation_id = $portDetails['id'];
-            $mail_allocation_port = $port;
+            $main_allocation_port = $port;
             $found_all = true;
             foreach($port_offsets as $key => $port_offset) {
                 $next_port = intval($port) + intval($port_offset);
@@ -805,7 +819,7 @@ function findFreePorts(array $available_allocations, array $port_offsets) {
                 logActivity("Main port allocation ID: ". $main_allocation_id);
                 logActivity("Additional port allocation ID's: ". print_r($additional_allocation_ids, true));
                 $result['main_allocation_id'] = $main_allocation_id;
-                $result['main_allocatiion_port'] = $mail_allocation_port;
+                $result['main_allocation_port'] = $main_allocation_port;
                 $result['additional_allocation_ids'] = $additional_allocation_ids;
                 $result['status'] = true;
                 return $result;
@@ -820,3 +834,4 @@ function findFreePorts(array $available_allocations, array $port_offsets) {
         return false;
     }
 }
+


### PR DESCRIPTION
Changed the way additional ports are assigned to instead use a json string, which allows you to specify the environment parameter name to set before the server creation API call is made.
E.g. You can assign a port to the server as normal, or specify a particular additional port to be set to the RCON_PORT parameter.