### PR TITLE
Fix additional allocation ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ E.g: If you enter `{"1":"NONE", "2":"NONE", "4":"NONE"}` and the first available
 
 (If they're available)
 
-Note: I this option is set, it will override anything specified under "port_range" - Use one or the other, not both.
+Note: I this option is set, it will override "Location ID" and "Dedicated IP".
 
 You'll also want to configure "**Additional Port Failure Mode**".
 This determines what the module should do if there are no allocations available on any of the defined nodes.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The customer gets an email from the panel to setup their account (incl. password
 ## My game requires multiple ports allocated.
 Configure the "**Additional Ports**" option in the module settings.
 It expects a valid JSON string consisting of the parameter name or NONE, and a number representing a port as a numeric offset from the first available allocation.
-E.g: If you enter `{1:"NONE", 2:"NONE", 4:"NONE"}` and the first available port happens to be 25565, you'll get as additional allocations: 
+E.g: If you enter `{"1":"NONE", "2":"NONE", "4":"NONE"}` and the first available port happens to be 25565, you'll get as additional allocations: 
 * 25566 (First Port + 1)
 * 25567 (First Port +2)
 * 25569 (First Port +4)
@@ -75,13 +75,13 @@ See the table below for "Additional Ports" example values.
 
 | Game | Required Ports  |Additional Ports Example  | Ports Assigned  |
 | ------------ | ------------ | ------------ | ------------ |
-| Rust | Game port and RCON port | `{1:"RCON_PORT"}`  | Game Port: 1000, RCON_PORT: 1001|
-| Arma 3 | Game port, Game port +1 for Steam Query, Game port + 2 for Steam Port, and Game port +4 for BattleEye |  `{1:"NONE", 2:"NONE", 4:"NONE"}` | Game Port: 1000, Additional Ports: 1001, 1002, 1004 |
-| Unturned | Game port, Game port +1 and Game port +2 | `{1:"NONE", 2:"NONE"}` | Game Port: 1000, Additional Ports: 1001, 1002 |
-| Project Zomboid | Game Port, Steam port and an additional port for every player. Let's say we want 10 additional ports for 10 players. | `{1:"STEAM_PORT", 2:"NONE", 3:"NONE", 4:"NONE", 5:"NONE", 6:"NONE", 7:"NONE", 8:"NONE", 9:"NONE", 10:"NONE", 11:"NONE"}` | Game Port: 1000, Steam Port: 1001, Additional Ports: 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010, 1011|
+| Rust | Game port and RCON port | `{"1":"RCON_PORT"}`  | Game Port: 1000, RCON_PORT: 1001|
+| Arma 3 | Game port, Game port +1 for Steam Query, Game port + 2 for Steam Port, and Game port +4 for BattleEye |  `{"1":"NONE", "2":"NONE", "4":"NONE"}` | Game Port: 1000, Additional Ports: 1001, 1002, 1004 |
+| Unturned | Game port, Game port +1 and Game port +2 | `{"1":"NONE", "2":"NONE"}` | Game Port: 1000, Additional Ports: 1001, 1002 |
+| Project Zomboid | Game Port, Steam port and an additional port for every player. Let's say we want 10 additional ports for 10 players. | `{"1":"STEAM_PORT", "2":"NONE", "3":"NONE", "4":"NONE", "5":"NONE", "6":"NONE", "7":"NONE", "8":"NONE", "9":"NONE", "10":"NONE", "11":"NONE"}` | Game Port: 1000, Steam Port: 1001, Additional Ports: 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010, 1011|
 
 **What does "NONE" mean?**
-"NONE" means you want to assign the additional port to the server, but it doesn't need to be assigned to a server parameter. If instead you want to add a +1 port and assign it to the parameter "RCON_PORT" then you'd use `{1:"RCON_PORT"}` for example.
+"NONE" means you want to assign the additional port to the server, but it doesn't need to be assigned to a server parameter. If instead you want to add a +1 port and assign it to the parameter "RCON_PORT" then you'd use `{"1":"RCON_PORT"}` for example.
 
 ## How to enable module debug log
 1. In WHMCS 7 or below navigate to Utilities > Logs > Module Log. For WHMCS 8.x navigate to System Logs > Module Log in the left sidebar.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ E.g: If you enter `{"1":"NONE", "2":"NONE", "4":"NONE"}` and the first available
 
 (If they're available)
 
-Note: I this option is set, it will override "Location ID" and "Dedicated IP".
+Note: Is this option is set, it will override "Location ID" and "Dedicated IP".
 
 You'll also want to configure "**Additional Port Failure Mode**".
 This determines what the module should do if there are no allocations available on any of the defined nodes.

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -286,7 +286,7 @@ function wisp_CreateAccount(array $params) {
                     'email' => $params['clientsdetails']['email'],
                     //set first_name and last_name if empty
                     'first_name' => empty($params['clientsdetails']['firstname']) ? 'Unkown' : $params['clientsdetails']['firstname'],
-                    'last_name' =>empty($params['clientsdetails']['lastname']) ? 'User' : $params['clientsdetails']['lastname'],
+                    'last_name' => empty($params['clientsdetails']['lastname']) ? 'User' : $params['clientsdetails']['lastname'],
                     'external_id' => $params['clientsdetails']['uuid'],
                 ], 'POST');
             } else {

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -284,8 +284,7 @@ function wisp_CreateAccount(array $params) {
             if($userResult['meta']['pagination']['total'] === 0) {
                 $userResult = wisp_API($params, 'users', [
                     'email' => $params['clientsdetails']['email'],
-                    //set first_name and last_name if empty
-                    'first_name' => empty($params['clientsdetails']['firstname']) ? 'Unkown' : $params['clientsdetails']['firstname'],
+                    'first_name' => empty($params['clientsdetails']['firstname']) ? 'Unknown' : $params['clientsdetails']['firstname'],
                     'last_name' => empty($params['clientsdetails']['lastname']) ? 'User' : $params['clientsdetails']['lastname'],
                     'external_id' => $params['clientsdetails']['uuid'],
                 ], 'POST');

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -284,8 +284,9 @@ function wisp_CreateAccount(array $params) {
             if($userResult['meta']['pagination']['total'] === 0) {
                 $userResult = wisp_API($params, 'users', [
                     'email' => $params['clientsdetails']['email'],
-                    'first_name' => $params['clientsdetails']['firstname'],
-                    'last_name' => $params['clientsdetails']['lastname'],
+                    //set first_name and last_name if empty
+                    'first_name' => empty($params['clientsdetails']['firstname']) ? 'Unkown' : $params['clientsdetails']['firstname'],
+                    'last_name' =>empty($params['clientsdetails']['lastname']) ? 'User' : $params['clientsdetails']['lastname'],
                     'external_id' => $params['clientsdetails']['uuid'],
                 ], 'POST');
             } else {

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -796,7 +796,7 @@ function findFreePorts(array $available_allocations, string $port_offsets) {
             $main_allocation_id = $portDetails['id'];
             $main_allocation_port = $port;
             $found_all = true;
-            foreach($port_offsets_array as $key => $port_offset) {
+            foreach($port_offsets_array as $port_offset => $environment) {
                 $next_port = intval($port) + intval($port_offset);
                 if(!isset($ports[$next_port])) {
                     // Port is not available
@@ -806,7 +806,7 @@ function findFreePorts(array $available_allocations, string $port_offsets) {
                     array_push($additional_allocation_ids, strval($ports[$next_port]['id']));
                     //array_push($additional_allocation_ports, strval($next_port));
 
-                    $additional_allocation_ports[$key] = $next_port;
+                    $additional_allocation_ports[$environment] = $next_port;
                 }
             }
             if($found_all == true) {

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -843,10 +843,9 @@ function findFreePorts(array $available_allocations, string $port_offsets,$deplo
                 $additional_allocation_ports = Array();
             }
         }
-
-        // Failed to find available set of ports based on requirements
-        logModuleCall("WISP-WHMCS", "Failed to find available ports!", "", "");
-        return false;
     }
+    // Failed to find available set of ports based on requirements
+    logModuleCall("WISP-WHMCS", "Failed to find available ports!", "", "");
+    return false;
 }
 

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -419,14 +419,14 @@ function wisp_CreateAccount(array $params) {
                     if($final_allocations != false && $final_allocations['status'] == true) {
                         $alloc_success = true;
                         logModuleCall("WISP-WHMCS", "Successfully found an allocation. Setting primary allocation to ID " . $final_allocations['main_allocation_id'], "", "");
-                        
+                        unset($serverData['deploy']);
                         $serverData['allocation']['default'] = intval($final_allocations['main_allocation_id']);
                         $serverData['allocation']['additional'] = $final_allocations['additional_allocation_ids'];
                         
                         // Update the environment parameters - additional allocations
                         foreach($final_allocations['additional_allocation_ports'] as $key => $port) {
                             // If the key given in the config had a value of NONE, don't worry about adding it to the environment parameters.
-                            if(substr( $key, 0, 5 ) !== "NONE_") {
+                            if(substr( $key, 0, 4 ) !== "NONE") {
                                 $serverData['environment'][$key] = $port;
                             }
                         }

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -687,7 +687,7 @@ function getNodes(array $params, int $loc_id) {
         Fetches and returns all nodes with a specific location_id
     */
     $filteredNodes = Array();
-    $nodes = wisp_API($params, 'nodes/');
+    $nodes = wisp_API($params, 'nodes');
     foreach($nodes['data'] as $key => $value) {
         $node_id = $value['attributes']['id'];
         if($value['attributes']['location_id'] == $loc_id) {

--- a/wisp/wisp.php
+++ b/wisp/wisp.php
@@ -789,7 +789,7 @@ function findFreePorts(array $available_allocations, string $port_offsets,$deplo
         $main_allocation_port = "";
         $additional_allocation_ids = Array();
         $additional_allocation_ports = Array();
-        if(isset($deploy["port_range"])){
+        if(!empty($deploy["port_range"])){
             $deploy["port_range"] = json_encode($deploy["port_range"]);
             //converts port_range string to object filled with int
             $portrange = [];


### PR DESCRIPTION
This PR should fix all bugs I came across while testing this module.

1. /applications/nodes endpoint
https://github.com/snags141/whmcs/blob/master/wisp/wisp.php#L690
`/api/application/nodes/` does always respond with a html error (I believe that work with wisp v1 but whatever)
I changed it to `/api/application/nodes` which seems to be the correct endpoint.

2.invalid JSON
https://github.com/snags141/whmcs/blob/master/README.md?plain=1#L77-L81
in JSON keys must be Strings (https://www.w3schools.com/js/js_json_objects.asp).
That's why 
`$port_offsets_array = json_decode($port_offsets, true);` (https://github.com/snags141/whmcs/blob/master/wisp/wisp.php#L782) never worked.

I updated the readme, so every key is now a string.
 

3.Foreach key and value are swapped
https://github.com/snags141/whmcs/blob/master/wisp/wisp.php#L799
There the key (which you use as port offset) is used as parameter name and the value (which you use as parameter name) is used as port offset.
I swapped them and used a more meaningful name.


The module works now, some Eggs have Port variables as Strings for them the user would need to change it to `numeric`.

(Tested with The Forest Egg)
